### PR TITLE
Reduce the file size of the frontend Docker image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:22
+FROM node:22-slim
 WORKDIR /frontend
-COPY package.json package-lock.json* ./
+COPY package*.json ./
 RUN npm install
 COPY . .
 EXPOSE 3000


### PR DESCRIPTION
This changes the base image for the frontend Docker image to node:22-slim, removing about 900Mb from the image file size.